### PR TITLE
#115 - Sanitize code used for creating barcodes.

### DIFF
--- a/code/scripts/controllers/batchesController.js
+++ b/code/scripts/controllers/batchesController.js
@@ -12,7 +12,7 @@ export default class batchesController extends WebcController {
 
     this.storageService.filter(constants.BATCHES_STORAGE_TABLE, "__timestamp > 0", (err, batches) => {
       batches.forEach((batch) => {
-        batch.code = this.generateSerializationForBatch(batch, batch.defaultSerialNumber);
+        batch.code = utils.sanitizeCode(this.generateSerializationForBatch(batch, batch.defaultSerialNumber));
         if (batch.defaultRecalledSerialNumber) {
           batch.recalledCode = this.generateSerializationForBatch(batch, batch.defaultRecalledSerialNumber);
         }
@@ -21,7 +21,7 @@ export default class batchesController extends WebcController {
         }
         let wrongBatch = JSON.parse(JSON.stringify(batch));
         wrongBatch.defaultSerialNumber = "WRONG";
-        batch.wrongCode = this.generateSerializationForBatch(wrongBatch, wrongBatch.defaultSerialNumber);
+        batch.wrongCode = utils.sanitizeCode(this.generateSerializationForBatch(wrongBatch, wrongBatch.defaultSerialNumber));
         batch.formatedDate = utils.convertDateFromISOToGS1Format(batch.expiryForDisplay, "/");
         this.model.batches.push(batch);
       });

--- a/code/scripts/utils.js
+++ b/code/scripts/utils.js
@@ -85,6 +85,10 @@ function sortByProperty (property, direction){
     }
 }
 
+function sanitizeCode(code) {
+    return code.replace(/"/g, "\\\"");
+}
+
 
 export default {
     convertDateFromISOToGS1Format,
@@ -92,5 +96,6 @@ export default {
     convertDateTOGMTFormat,
     getFetchUrl,
     fetch: executeFetch,
-    sortByProperty
+    sortByProperty,
+    sanitizeCode
 }


### PR DESCRIPTION
This PR adds better support for creating barcodes and relates to this task: https://github.com/PharmaLedger-IMI/epi-workspace/issues/115

It solves problem with using " character in batch or gtin. I was not able to test serial numbers yet.

Barcodes that include " character are currently not valid for interpretGS1scan, but they are read correctly with Scandit.